### PR TITLE
ci: Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/buildtools.yml
+++ b/.github/workflows/buildtools.yml
@@ -60,7 +60,7 @@ jobs:
           zip -r $GITHUB_WORKSPACE/x86_64-linux-buildtools-${{ matrix.haiku_arch }}-${{ steps.get_btrev.outputs.btrev }}.zip cross-tools-*
       - name: Upload artifacts
         if: steps.get_btrev.outputs.btrev != steps.get_buildtools.outputs.btrev
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: x86_64-linux-buildtools-${{ matrix.haiku_arch }}-${{ steps.get_btrev.outputs.btrev }}
           path: x86_64-linux-buildtools-${{ matrix.haiku_arch }}-${{ steps.get_btrev.outputs.btrev }}.zip

--- a/.github/workflows/hosttools.yml
+++ b/.github/workflows/hosttools.yml
@@ -81,7 +81,7 @@ jobs:
             -x *.o
       - name: Upload artifacts
         if: steps.get_hrev.outputs.hrev != steps.get_hosttools.outputs.hrev
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: x86_64-linux-hosttools-${{ steps.get_hrev.outputs.hrev }}
           path: x86_64-linux-hosttools-${{ steps.get_hrev.outputs.hrev }}.zip


### PR DESCRIPTION
v3 is deprecated and is causing jobs to fail.

Fixes the annoying daily run failure emails, and allows dependent projects to get the latest tools.