### PR TITLE
ci: Bump actions versions to 6-7

### DIFF
--- a/.github/workflows/buildtools.yml
+++ b/.github/workflows/buildtools.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check latest Haiku buildtools btrev
         id: get_btrev
         run: |
@@ -60,7 +60,7 @@ jobs:
           zip -r $GITHUB_WORKSPACE/x86_64-linux-buildtools-${{ matrix.haiku_arch }}-${{ steps.get_btrev.outputs.btrev }}.zip cross-tools-*
       - name: Upload artifacts
         if: steps.get_btrev.outputs.btrev != steps.get_buildtools.outputs.btrev
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: x86_64-linux-buildtools-${{ matrix.haiku_arch }}-${{ steps.get_btrev.outputs.btrev }}
           path: x86_64-linux-buildtools-${{ matrix.haiku_arch }}-${{ steps.get_btrev.outputs.btrev }}.zip

--- a/.github/workflows/hosttools.yml
+++ b/.github/workflows/hosttools.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check latest Haiku hrev
         id: get_hrev
         run: |
@@ -81,7 +81,7 @@ jobs:
             -x *.o
       - name: Upload artifacts
         if: steps.get_hrev.outputs.hrev != steps.get_hosttools.outputs.hrev
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: x86_64-linux-hosttools-${{ steps.get_hrev.outputs.hrev }}
           path: x86_64-linux-hosttools-${{ steps.get_hrev.outputs.hrev }}.zip


### PR DESCRIPTION
1. Bump `checkout` to v6.
2. Bump `upload-artifact` to v7.

`actions/checkout@v3` uses Node.js 20, which is deprecated on GitHub Actions.